### PR TITLE
simulator fix

### DIFF
--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -266,6 +266,14 @@ class SBC:
             initial=self._simulations_complete,
             total=self.num_simulations,
         )
+
+        # if simulator is used, ignore observed_vars
+        if self.simulator is not None:
+            self.observed_vars = list(prior_pred.data_vars)
+            self.var_names = list(filter(lambda var_name: var_name not in self.observed_vars,
+                                    list(prior.data_vars)))
+            self.simulations = {var_name: [] for var_name in self.var_names}
+            
         try:
             while self._simulations_complete < self.num_simulations:
                 idx = self._simulations_complete
@@ -297,6 +305,12 @@ class SBC:
             initial=self._simulations_complete,
             total=self.num_simulations,
         )
+        # if simulator is used, ignore observed_vars
+        if self.simulator is not None:
+            self.observed_vars = list(prior_pred.keys())
+            self.var_names = list(filter(lambda var_name: var_name not in self.observed_vars,
+                                    list(prior.keys())))
+            self.simulations = {var_name: [] for var_name in self.var_names}
         try:
             while self._simulations_complete < self.num_simulations:
                 idx = self._simulations_complete

--- a/simuk/tests/test_sbc.py
+++ b/simuk/tests/test_sbc.py
@@ -28,11 +28,7 @@ with pm.Model() as centered_eight_no_observed:
     mu = pm.Normal("mu", mu=0, sigma=5)
     tau = pm.HalfCauchy("tau", beta=5)
     theta = pm.Normal("theta", mu=mu, sigma=tau, shape=8)
-
-    def log_likelihood(theta, observed):
-        return pm.math.sum(pm.logp(pm.Normal.dist(mu=theta, sigma=sigma), observed))
-
-    pm.Potential("y_loglike", log_likelihood(mu, data))
+    y_obs = pm.Normal("y", mu=theta, sigma=sigma)
 
 # Bambi model
 x = np.random.normal(0, 1, 20)


### PR DESCRIPTION
- set observed and free var names based on the simulator output.
- modify centered_eight_no_observed model in test to have explicit y variable so as to allow condition on the y output of the simulator. It was failing silently, as we didn't set var names based on the simulator output, and the prior predictive draws were empty.