### PR TITLE
Fix numpyro wrongly conditioning on non-sample sites  

### DIFF
--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -16,8 +16,8 @@ try:
 except ImportError:
     pass
 
-from collections.abc import Mapping
 import inspect
+from collections.abc import Mapping
 
 import numpy as np
 from arviz_base import dict_to_dataset, extract, from_dict, from_numpyro

--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -140,7 +140,7 @@ class SBC:
                 "predictive samples. Either change the model or specify a simulator "
                 "with the `simulator` argument."
             )
-        
+
         if simulator is None and self.engine == "numpyro":
             if not self.observed_model_vars:
                 raise ValueError(
@@ -148,13 +148,12 @@ class SBC:
                     "will not generate prior predictive samples. Either change the model "
                     "or specify a simulator with the `simulator` argument."
                 )
-            missing = [
-                name for name in self.observed_model_vars if name not in self.data_dir
-            ]
+            missing = [name for name in self.observed_model_vars if name not in self.data_dir]
             if missing:
                 raise ValueError(
-                    "The following model parameters are missing from data_dir: "
-                    ", ".join(sorted(missing))
+                    "The following model parameters are missing from data_dir: , ".join(
+                        sorted(missing)
+                    )
                 )
         self.simulator = simulator
 
@@ -177,7 +176,7 @@ class SBC:
             ]
             # Observed model variables are those that are marked as observed
             # and are also model function parameters in order to be able to condition on them.
-            # For instance, this is used to filter out factor variables that are marked as observed 
+            # For instance, this is used to filter out factor variables that are marked as observed
             # but cannot be conditioned on.
             self.observed_model_vars = [
                 name for name in self.observed_vars if name in self.model_params
@@ -205,25 +204,20 @@ class SBC:
             # Deal with custom simulator
             prior_pred = []
             for i in range(prior.sizes["sample"]):
-                params = {
-                    var: prior[var].isel(sample=i).values for var in prior.data_vars
-                }
+                params = {var: prior[var].isel(sample=i).values for var in prior.data_vars}
                 params["seed"] = self._seeds[i]
                 try:
                     res = self.simulator(**params)
-                    assert isinstance(
-                        res, Mapping
-                    ), f"Simulator must return a dictionary, got {type(res)}"
+                    assert isinstance(res, Mapping), (
+                        f"Simulator must return a dictionary, got {type(res)}"
+                    )
                     prior_pred.append(res)
                 except Exception as e:
                     raise ValueError(
                         f"Error generating prior predictive sample with parameters {params}: {e}."
                     )
             prior_pred = dict_to_dataset(
-                {
-                    key: np.stack([pp[key] for pp in prior_pred])
-                    for key in prior_pred[0]
-                },
+                {key: np.stack([pp[key] for pp in prior_pred]) for key in prior_pred[0]},
                 sample_dims=["sample"],
                 coords={**prior.coords},
             )
@@ -233,9 +227,9 @@ class SBC:
         """Generate samples to use for the simulations using numpyro."""
         predictive = Predictive(self.model, num_samples=self.num_simulations)
         free_vars_data = {
-            k: v for k, v in self.data_dir.items() 
-            if k not in self.observed_vars
-            and k in self.model_params
+            k: v
+            for k, v in self.data_dir.items()
+            if k not in self.observed_vars and k in self.model_params
         }
         samples = predictive(jax.random.PRNGKey(self._seeds[0]), **free_vars_data)
         prior = {k: v for k, v in samples.items() if k not in self.observed_vars}
@@ -245,9 +239,7 @@ class SBC:
                 params = dict(zip(prior.keys(), vals))
                 params["seed"] = self._seeds[i]
                 results.append(self.simulator(**params))
-            prior_pred = {
-                key: [result[key] for result in results] for key in results[0]
-            }
+            prior_pred = {key: [result[key] for result in results] for key in results[0]}
         else:
             prior_pred = {k: v for k, v in samples.items() if k in self.observed_model_vars}
         return prior, prior_pred
@@ -331,9 +323,7 @@ class SBC:
                 posterior = self._get_posterior_samples(prior_predictive_draw)
                 for name in self.var_names:
                     self.simulations[name].append(
-                        (posterior[name] < prior[name].sel(chain=0, draw=idx))
-                        .sum("sample")
-                        .values
+                        (posterior[name] < prior[name].sel(chain=0, draw=idx)).sum("sample").values
                     )
                 self._simulations_complete += 1
                 progress.update()
@@ -361,7 +351,7 @@ class SBC:
             ]
             if not self.observed_model_vars:
                 raise ValueError("No observed variables to condition on")
-            
+
             self.var_names = list(
                 filter(
                     lambda var_name: var_name not in self.observed_vars,
@@ -376,9 +366,7 @@ class SBC:
                 posterior = self._get_posterior_samples_numpyro(prior_predictive_draw)
                 for name in self.var_names:
                     self.simulations[name].append(
-                        (posterior[name].sel(chain=0) < prior[name][idx])
-                        .sum(axis=0)
-                        .values
+                        (posterior[name].sel(chain=0) < prior[name][idx]).sum(axis=0).values
                     )
                 self._simulations_complete += 1
                 progress.update()

--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -151,9 +151,8 @@ class SBC:
             missing = [name for name in self.observed_model_vars if name not in self.data_dir]
             if missing:
                 raise ValueError(
-                    "The following model parameters are missing from data_dir: , ".join(
-                        sorted(missing)
-                    )
+                    "The following model parameters are missing from data_dir: "
+                    + ", ".join(sorted(missing))
                 )
         self.simulator = simulator
 

--- a/simuk/sbc.py
+++ b/simuk/sbc.py
@@ -17,6 +17,7 @@ except ImportError:
     pass
 
 from collections.abc import Mapping
+import inspect
 
 import numpy as np
 from arviz_base import dict_to_dataset, extract, from_dict, from_numpyro
@@ -102,7 +103,7 @@ class SBC:
             self.numpyro_model = model
             self.model = self.numpyro_model.model
             self.run_simulations = self._run_simulations_numpyro
-            self.data_dir = data_dir
+            self.data_dir = data_dir if data_dir is not None else {}
         else:
             raise ValueError(
                 "model should be one of pymc.Model, bambi.Model, or numpyro.infer.mcmc.MCMCKernel"
@@ -123,6 +124,7 @@ class SBC:
         self._extract_variable_names()
         self.simulations = {name: [] for name in self.var_names}
         self._simulations_complete = 0
+
         if simulator is not None and not callable(simulator):
             raise ValueError("simulator should be a function or None")
         if simulator is not None and self.observed_vars:
@@ -138,11 +140,28 @@ class SBC:
                 "predictive samples. Either change the model or specify a simulator "
                 "with the `simulator` argument."
             )
+        
+        if simulator is None and self.engine == "numpyro":
+            if not self.observed_model_vars:
+                raise ValueError(
+                    "There are no observed variables we can condition on, and NumPyro "
+                    "will not generate prior predictive samples. Either change the model "
+                    "or specify a simulator with the `simulator` argument."
+                )
+            missing = [
+                name for name in self.observed_model_vars if name not in self.data_dir
+            ]
+            if missing:
+                raise ValueError(
+                    "The following model parameters are missing from data_dir: "
+                    ", ".join(sorted(missing))
+                )
         self.simulator = simulator
 
     def _extract_variable_names(self):
         """Extract observed and free variables from the model."""
         if self.engine == "numpyro":
+            self.model_params = set(inspect.signature(self.model).parameters.keys())
             with trace() as tr:
                 with seed(rng_seed=int(self._seeds[0])):
                     self.numpyro_model.model(**self.data_dir)
@@ -156,6 +175,14 @@ class SBC:
                 for name, site in tr.items()
                 if site["type"] == "sample" and site.get("is_observed", False)
             ]
+            # Observed model variables are those that are marked as observed
+            # and are also model function parameters in order to be able to condition on them.
+            # For instance, this is used to filter out factor variables that are marked as observed 
+            # but cannot be conditioned on.
+            self.observed_model_vars = [
+                name for name in self.observed_vars if name in self.model_params
+            ]
+
         else:
             self.observed_vars = [obs.name for obs in self.model.observed_RVs]
             self.var_names = [v.name for v in self.model.free_RVs]
@@ -178,20 +205,25 @@ class SBC:
             # Deal with custom simulator
             prior_pred = []
             for i in range(prior.sizes["sample"]):
-                params = {var: prior[var].isel(sample=i).values for var in prior.data_vars}
+                params = {
+                    var: prior[var].isel(sample=i).values for var in prior.data_vars
+                }
                 params["seed"] = self._seeds[i]
                 try:
                     res = self.simulator(**params)
-                    assert isinstance(res, Mapping), (
-                        f"Simulator must return a dictionary, got {type(res)}"
-                    )
+                    assert isinstance(
+                        res, Mapping
+                    ), f"Simulator must return a dictionary, got {type(res)}"
                     prior_pred.append(res)
                 except Exception as e:
                     raise ValueError(
                         f"Error generating prior predictive sample with parameters {params}: {e}."
                     )
             prior_pred = dict_to_dataset(
-                {key: np.stack([pp[key] for pp in prior_pred]) for key in prior_pred[0]},
+                {
+                    key: np.stack([pp[key] for pp in prior_pred])
+                    for key in prior_pred[0]
+                },
                 sample_dims=["sample"],
                 coords={**prior.coords},
             )
@@ -200,7 +232,11 @@ class SBC:
     def _get_prior_predictive_samples_numpyro(self):
         """Generate samples to use for the simulations using numpyro."""
         predictive = Predictive(self.model, num_samples=self.num_simulations)
-        free_vars_data = {k: v for k, v in self.data_dir.items() if k not in self.observed_vars}
+        free_vars_data = {
+            k: v for k, v in self.data_dir.items() 
+            if k not in self.observed_vars
+            and k in self.model_params
+        }
         samples = predictive(jax.random.PRNGKey(self._seeds[0]), **free_vars_data)
         prior = {k: v for k, v in samples.items() if k not in self.observed_vars}
         if self.simulator:
@@ -209,9 +245,11 @@ class SBC:
                 params = dict(zip(prior.keys(), vals))
                 params["seed"] = self._seeds[i]
                 results.append(self.simulator(**params))
-            prior_pred = {key: [result[key] for result in results] for key in results[0]}
+            prior_pred = {
+                key: [result[key] for result in results] for key in results[0]
+            }
         else:
-            prior_pred = {k: v for k, v in samples.items() if k in self.observed_vars}
+            prior_pred = {k: v for k, v in samples.items() if k in self.observed_model_vars}
         return prior, prior_pred
 
     def _get_posterior_samples(self, prior_predictive_draw):
@@ -219,7 +257,8 @@ class SBC:
         new_model = pm.observe(self.model, prior_predictive_draw)
         with new_model:
             check = pm.sample(
-                **self.sample_kwargs, random_seed=self._seeds[self._simulations_complete]
+                **self.sample_kwargs,
+                random_seed=self._seeds[self._simulations_complete],
             )
 
         posterior = extract(check, group="posterior", keep_dataset=True)
@@ -229,13 +268,16 @@ class SBC:
         """Generate posterior samples using numpyro conditioned to a prior predictive sample."""
         mcmc = MCMC(self.numpyro_model, **self.sample_kwargs)
         rng_seed = jax.random.PRNGKey(self._seeds[self._simulations_complete])
-        # If using a custom simulator, some variables present in `prior_predictive_draw`
-        # might be missing from self.observed_vars.
-        # TODO: Not sure if the union is redundant here and perhaps prior_predictive_draw.keys()
-        # could be sufficient.
-        extended_observed_vars = set(prior_predictive_draw.keys()).union(self.observed_vars)
-        free_vars_data = {k: v for k, v in self.data_dir.items() if k not in extended_observed_vars}
-        mcmc.run(rng_seed, **free_vars_data, **prior_predictive_draw)
+
+        free_vars_data = {
+            k: v
+            for k, v in self.data_dir.items()
+            if k not in self.observed_model_vars and k in self.model_params
+        }
+        prior_predictive_args = {
+            k: v for k, v in prior_predictive_draw.items() if k in self.observed_model_vars
+        }
+        mcmc.run(rng_seed, **free_vars_data, **prior_predictive_args)
         return from_numpyro(mcmc)["posterior"]
 
     def _convert_to_datatree(self):
@@ -271,7 +313,10 @@ class SBC:
         if self.simulator is not None:
             self.observed_vars = list(prior_pred.data_vars)
             self.var_names = list(
-                filter(lambda var_name: var_name not in self.observed_vars, list(prior.data_vars))
+                filter(
+                    lambda var_name: var_name not in self.observed_vars,
+                    list(prior.data_vars),
+                )
             )
             self.simulations = {var_name: [] for var_name in self.var_names}
 
@@ -286,7 +331,9 @@ class SBC:
                 posterior = self._get_posterior_samples(prior_predictive_draw)
                 for name in self.var_names:
                     self.simulations[name].append(
-                        (posterior[name] < prior[name].sel(chain=0, draw=idx)).sum("sample").values
+                        (posterior[name] < prior[name].sel(chain=0, draw=idx))
+                        .sum("sample")
+                        .values
                     )
                 self._simulations_complete += 1
                 progress.update()
@@ -309,8 +356,17 @@ class SBC:
         # if simulator is used, ignore observed_vars
         if self.simulator is not None:
             self.observed_vars = list(prior_pred.keys())
+            self.observed_model_vars = [
+                name for name in self.observed_vars if name in self.model_params
+            ]
+            if not self.observed_model_vars:
+                raise ValueError("No observed variables to condition on")
+            
             self.var_names = list(
-                filter(lambda var_name: var_name not in self.observed_vars, list(prior.keys()))
+                filter(
+                    lambda var_name: var_name not in self.observed_vars,
+                    list(prior.keys()),
+                )
             )
             self.simulations = {var_name: [] for var_name in self.var_names}
         try:
@@ -320,7 +376,9 @@ class SBC:
                 posterior = self._get_posterior_samples_numpyro(prior_predictive_draw)
                 for name in self.var_names:
                     self.simulations[name].append(
-                        (posterior[name].sel(chain=0) < prior[name][idx]).sum(axis=0).values
+                        (posterior[name].sel(chain=0) < prior[name][idx])
+                        .sum(axis=0)
+                        .values
                     )
                 self._simulations_complete += 1
                 progress.update()

--- a/simuk/tests/test_sbc.py
+++ b/simuk/tests/test_sbc.py
@@ -56,6 +56,11 @@ def eight_schools_cauchy_prior_no_observed(J, sigma, y=None):
         numpyro.factor("custom_likelihood", log_likelihood)
 
 
+def numpyro_model_double_observed(y1=jnp.array([0.0]), y2=jnp.array([0.0])):
+    numpyro.sample("y1", dist.Normal(0, 1), obs=y1)
+    numpyro.sample("y2", dist.Normal(0, 1), obs=y2)
+
+
 # Custom simulator functions
 def centered_eight_simulator(theta, seed, **kwargs):
     rng = np.random.default_rng(seed)
@@ -174,4 +179,39 @@ def test_sbc_numpyro_fail_no_observed_variable():
             num_simulations=10,
             sample_kwargs={"num_warmup": 50, "num_samples": 25},
         )
+        sbc.run_simulations()
+
+
+def test_sbc_numpyro_missing_observed_data():
+    with pytest.raises(ValueError, match="missing from data_dir"):
+        simuk.SBC(
+            NUTS(numpyro_model_double_observed),
+            data_dir={"y2": [0.0]},
+            num_simulations=10,
+            sample_kwargs={"num_warmup": 10, "num_samples": 5},
+        )
+
+
+def test_sbc_numpyro_empty_observed_data():
+    with pytest.raises(ValueError, match="no observed variables"):
+        simuk.SBC(
+            NUTS(eight_schools_cauchy_prior),
+            data_dir={"J": 8, "sigma": sigma},
+            num_simulations=10,
+            sample_kwargs={"num_warmup": 10, "num_samples": 5},
+        )
+
+
+def test_sbc_numpyro_simulator_no_conditionable_observed():
+    def bad_simulator(**kwargs):
+        return {"not_a_param": np.array([0.0])}
+
+    sbc = simuk.SBC(
+        NUTS(eight_schools_cauchy_prior),
+        data_dir={"J": 8, "sigma": sigma, "y": data},
+        num_simulations=5,
+        sample_kwargs={"num_warmup": 10, "num_samples": 5},
+        simulator=bad_simulator,
+    )
+    with pytest.raises(ValueError, match="No observed variables to condition on"):
         sbc.run_simulations()


### PR DESCRIPTION
This fixes test `test_sbc_numpyro_fail_no_observed_variable`. The expected behavior is to raise an ValueError since there is no actual observed variable to condition on.

Factor sites in numpyro is classified as a observed site when the criterion is the existence of `is_observed` attr. 

This means the prior predicitve draw will output Factor sites values for the model to condition on. This is however not only against the user's intention as the provided model function itself does not have the corresponding args, which would yield a TypeError, we also can't supply observed data to factor sites. 

The previous test was failing silently as the try except block below catches the error raised in `_get_posterior_samples_numpyro` on the first iteration, making the `self.simulations` dict empty, in turn raising another error when attempting to stack an empty array in the `finally` block, which is conveniently also an ValueError. And the negative test, see that an error is raised and interpreted the eerror handling as correct.

https://github.com/arviz-devs/simuk/blob/6ed2d1ca6718e6b26b6f049d5821fcc1f312ff89/simuk/sbc.py#L316-L333